### PR TITLE
ci(dependabot): add safe auto-merge for patch updates (CI required)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,8 +30,7 @@ jobs:
             const payload = context.payload;
 
             // define owner/repo early — we'll need them if we lookup PRs by commit SHA
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+            // owner/repo already defined above
             let pr = payload.pull_request;
 
             // If the workflow run was triggered by a check_run/check_suite event,


### PR DESCRIPTION
Adds workflow to auto-merge Dependabot PRs only when semver patch updates and CI checks pass. This keeps small patches moving while staying safe.