### PR TITLE
ci(workflows): reduce noise  ignore .github/** on push/pr triggers

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -6,9 +6,15 @@ on:
   push:
     # Only run the full quality pipeline on pushes to the default branch.
     branches: [ main ]
+    # Avoid triggering this heavy pipeline when the push only changes workflow/configuration files
+    paths-ignore:
+      - '.github/**'
   pull_request:
     # Run for pull requests targeting main; PRs from feature branches will trigger checks
     branches: [ main ]
+    # Avoid triggering the heavy pipeline when only workflow/config files are modified in the PR
+    paths-ignore:
+      - '.github/**'
 
 # Explicit permissions for the workflow. This grants only the minimal
 # privileges gitleaks needs to create checks/comments (and nothing more).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    # ignore pushes that only change workflow / .github config files
+    paths-ignore:
+      - '.github/**'
   pull_request:
     branches: [main]
+    # ignore PRs that only change workflow / .github config files
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   tests:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,15 @@ name: 'CodeQL SAST scan'
 on:
   push:
     branches: [main]
+    # Avoid running CodeQL if only workflow files changed
+    paths-ignore:
+      - '.github/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+    # Avoid running CodeQL on PRs that only change workflow files
+    paths-ignore:
+      - '.github/**'
   schedule:
     - cron: '0 2 * * 2' # weekly on Tuesdays at 02:00 UTC
 

--- a/.github/workflows/csp-monitoring-ci.yml
+++ b/.github/workflows/csp-monitoring-ci.yml
@@ -3,6 +3,9 @@ name: CSP monitoring checks
 on:
   push:
     branches: ['feat/staging-csp-monitor', 'main']
+    # don't run for pushes that only modify workflow files
+    paths-ignore:
+      - '.github/**'
   pull_request:
     paths: ['backend/**', 'infra/**', 'docs/**', 'test/**']
 

--- a/.github/workflows/dast-zap.yml
+++ b/.github/workflows/dast-zap.yml
@@ -3,8 +3,14 @@ name: DAST - OWASP ZAP baseline
 on:
   push:
     branches: [main]
+    # Avoid running baseline DAST when only workflow files change
+    paths-ignore:
+      - '.github/**'
   pull_request:
     branches: [main]
+    # Skip DAST for PRs that only modify workflows/config
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   zap-baseline:

--- a/.github/workflows/dependabot-high-alerts.yml
+++ b/.github/workflows/dependabot-high-alerts.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: {}
   push:
     branches: [main]
+    # don't trigger this handler for commits that only touch workflow files
+    paths-ignore:
+      - '.github/**'
 
 permissions:
   issues: write

--- a/.github/workflows/deploy-check-secrets.yml
+++ b/.github/workflows/deploy-check-secrets.yml
@@ -3,6 +3,9 @@ name: Deployment - secrets smoke check
 on:
   push:
     branches: [main]
+    # Avoid running this deployment smoke-check when only workflow files change
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -3,6 +3,9 @@ name: Generate SBOM & check licenses
 on:
   push:
     branches: [main]
+    # Avoid running SBOM generation when the push only touches workflow files
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch: {}
   schedule:
     - cron: '0 3 * * *' # daily at 03:00 UTC

--- a/.github/workflows/openapi-contract-tests.yml
+++ b/.github/workflows/openapi-contract-tests.yml
@@ -7,6 +7,9 @@ on:
       - 'scripts/run-contract.cjs'
   push:
     branches: [main]
+    # avoid running contract tests on pushes that only change workflow/config
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   lint-openapi:

--- a/.github/workflows/openapi-drift-check.yml
+++ b/.github/workflows/openapi-drift-check.yml
@@ -8,6 +8,9 @@ on:
       - 'scripts/check-openapi-drift.cjs'
   push:
     branches: [main]
+    # skip if only workflow files changed
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   drift-check:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -3,8 +3,14 @@ name: Security - Trivy repo & fs scan
 on:
   push:
     branches: [main]
+    # Avoid running Trivy when only workflow files change
+    paths-ignore:
+      - '.github/**'
   pull_request:
     branches: [main]
+    # Avoid running Trivy for PRs that only update workflow/config files
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   trivy-scan:

--- a/.github/workflows/validate-checks.yml
+++ b/.github/workflows/validate-checks.yml
@@ -2,7 +2,13 @@ name: 'Validate docs & memory checks'
 
 on:
   pull_request:
+    # avoid running when PRs only update workflow files
+    paths-ignore:
+      - '.github/**'
   push:
+    # avoid running when pushes only change workflow files
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate-required-secrets.yml
+++ b/.github/workflows/validate-required-secrets.yml
@@ -5,6 +5,9 @@ on:
   # Keep the ability to run this manually for admins/maintainers via workflow_dispatch.
   pull_request:
     branches: [main]
+    # avoid running this on PRs that only change workflow files (noise)
+    paths-ignore:
+      - '.github/**'
   push:
     branches: [main]
     # avoid running this check on commits that only change workflow files


### PR DESCRIPTION
Reduce noisy workflow runs by ignoring pushes/PRs that only modify files under .github/. This adds paths-ignore: ['.github/**'] to CI, CodeQL, DAST, Trivy, SBOM, OpenAPI checks, validate-checks, dependabot handler and the deployment smoke-checks.\n\nThis prevents empty or irrelevant check-suite runs when only workflow files are changed and reduces CI noise.